### PR TITLE
Added Targeted PS Repository

### DIFF
--- a/HPCMLS/Detect.ps1
+++ b/HPCMLS/Detect.ps1
@@ -34,18 +34,18 @@ if ($Providers.Name -notcontains "NuGet") {
 
 if ($ProviderInstalled) {
     $PowerShellGetInstalledModule = Get-InstalledModule -Name "PowerShellGet" -ErrorAction SilentlyContinue -Verbose:$false
-    if ($PowerShellGetInstalledModule -ne $null) {
+    if ($null -ne $PowerShellGetInstalledModule) {
         try {
             # Attempt to locate the latest available version of the PowerShellGet module from repository
             Write-Output "Attempting to request the latest PowerShellGet module version from repository" 
             $PowerShellGetLatestModule = Find-Module -Name "PowerShellGet" -ErrorAction Stop -Verbose:$false
-            if ($PowerShellGetLatestModule -ne $null) {
+            if ($null -ne $PowerShellGetLatestModule) {
                 if ($PowerShellGetInstalledModule.Version -lt $PowerShellGetLatestModule.Version) {
                     Write-Output "Newer PowerShellGet version detected, update from repository is needed";exit 1
                 } else {
                     Write-Output "PowershellGet is Ready"
                     $HPInstalledModule = Get-InstalledModule | Where-Object {$_.Name -match "HPCMSL"} -ErrorAction SilentlyContinue -Verbose:$false
-                    if ($HPInstalledModule -ne $null) {
+                    if ($null -ne $HPInstalledModule) {
                         $HPGetLatestModule = Find-Module -Name "HPCMSL" -Repository $PSRepository -ErrorAction Stop -Verbose:$false
                         if ($HPInstalledModule.Version -lt $HPGetLatestModule.Version) {
                             Write-Output "Newer HPCMSL version detected, update from repository is needed";exit 1

--- a/HPCMLS/Detect.ps1
+++ b/HPCMLS/Detect.ps1
@@ -1,7 +1,11 @@
-#HP HPCMLS Detection Script 
+#HP HPCMSL Detection Script 
 #Created by: 
 #Jan Ketil Skanke & Maurice Daly 
 #MSEndpointMgr.com 
+
+#Declarations
+
+$PSRepository = "PSGallery"
 
 #Start Detection
 #Validate that script is executed on HP hardware
@@ -42,7 +46,7 @@ if ($ProviderInstalled) {
                     Write-Output "PowershellGet is Ready"
                     $HPInstalledModule = Get-InstalledModule | Where-Object {$_.Name -match "HPCMSL"} -ErrorAction SilentlyContinue -Verbose:$false
                     if ($HPInstalledModule -ne $null) {
-                        $HPGetLatestModule = Find-Module -Name "HPCMSL" -ErrorAction Stop -Verbose:$false
+                        $HPGetLatestModule = Find-Module -Name "HPCMSL" -Repository $PSRepository -ErrorAction Stop -Verbose:$false
                         if ($HPInstalledModule.Version -lt $HPGetLatestModule.Version) {
                             Write-Output "Newer HPCMSL version detected, update from repository is needed";exit 1
                         } else {

--- a/HPCMLS/Remeditate.ps1
+++ b/HPCMLS/Remeditate.ps1
@@ -68,12 +68,12 @@ catch [System.Exception] {
 # Install the latest PowershellGet Module 
 if ($PackageProvider.Version -ge "2.8.5"){
     $PowerShellGetInstalledModule = Get-InstalledModule -Name "PowerShellGet" -ErrorAction SilentlyContinue -Verbose:$false
-    if ($PowerShellGetInstalledModule -ne $null) {
+    if ($null -ne $PowerShellGetInstalledModule) {
         try {
             # Attempt to locate the latest available version of the PowerShellGet module from repository
             Write-Output "Attempting to request the latest PowerShellGet module version from repository" 
             $PowerShellGetLatestModule = Find-Module -Name "PowerShellGet" -Repository $PSRepository -ErrorAction Stop -Verbose:$false
-            if ($PowerShellGetLatestModule -ne $null) {
+            if ($null -ne $PowerShellGetLatestModule) {
                 if ($PowerShellGetInstalledModule.Version -lt $PowerShellGetLatestModule.Version) {
                     try {
                         # Newer module detected, attempt to update
@@ -108,7 +108,7 @@ if ($PackageProvider.Version -ge "2.8.5"){
     
     #Install the latest HPCMSL Module
     $HPInstalledModule = Get-InstalledModule | Where-Object {$_.Name -match "HPCMSL"} -ErrorAction SilentlyContinue -Verbose:$false
-    if ($HPInstalledModule -ne $null) {
+    if ($null -ne $HPInstalledModule) {
         $HPGetLatestModule = Find-Module -Name "HPCMSL" -Repository $PSRepository -ErrorAction Stop -Verbose:$false
         if ($HPInstalledModule.Version -lt $HPGetLatestModule.Version) {
             Write-Output "Newer HPCMSL version detected, updating from repository"

--- a/HPCMLS/Remeditate.ps1
+++ b/HPCMLS/Remeditate.ps1
@@ -1,8 +1,12 @@
-#HP HPCMLS Detection Script 
+#HP HPCMSL Detection Script 
 #Created by: 
 #Jan Ketil Skanke & Maurice Daly 
 #MSEndpointMgr.com 
 #Start-PowerShellSysNative is inspired by @NickolajA's method to install the HPCMLS module 
+
+#Declarations
+
+$PSRepository = "PSGallery"
 
 #Start remediate
 #This remediation must run in system context and in 64bit powershell. 
@@ -68,7 +72,7 @@ if ($PackageProvider.Version -ge "2.8.5"){
         try {
             # Attempt to locate the latest available version of the PowerShellGet module from repository
             Write-Output "Attempting to request the latest PowerShellGet module version from repository" 
-            $PowerShellGetLatestModule = Find-Module -Name "PowerShellGet" -ErrorAction Stop -Verbose:$false
+            $PowerShellGetLatestModule = Find-Module -Name "PowerShellGet" -Repository $PSRepository -ErrorAction Stop -Verbose:$false
             if ($PowerShellGetLatestModule -ne $null) {
                 if ($PowerShellGetInstalledModule.Version -lt $PowerShellGetLatestModule.Version) {
                     try {
@@ -93,9 +97,9 @@ if ($PackageProvider.Version -ge "2.8.5"){
             # PowerShellGet module was not found, attempt to install from repository
             Write-Output "PowerShellGet module was not found, attempting to install it including dependencies from repository" 
             Write-Output "Attempting to install PackageManagement module from repository" 
-            Install-Module -Name "PackageManagement" -Force -Scope AllUsers -AllowClobber -ErrorAction Stop -Verbose:$false
+            Install-Module -Name "PackageManagement" -Repository $PSRepository -Force -Scope AllUsers -AllowClobber -ErrorAction Stop -Verbose:$false
             Write-Output "Attempting to install PowerShellGet module from repository" 
-            Install-Module -Name "PowerShellGet" -Force -Scope AllUsers -AllowClobber -ErrorAction Stop -Verbose:$false
+            Install-Module -Name "PowerShellGet" -Repository $PSRepository -Force -Scope AllUsers -AllowClobber -ErrorAction Stop -Verbose:$false
         }
         catch [System.Exception] {
             Write-Output "Unable to install PowerShellGet module from repository. Error message: $($_.Exception.Message)"; exit 1
@@ -105,7 +109,7 @@ if ($PackageProvider.Version -ge "2.8.5"){
     #Install the latest HPCMSL Module
     $HPInstalledModule = Get-InstalledModule | Where-Object {$_.Name -match "HPCMSL"} -ErrorAction SilentlyContinue -Verbose:$false
     if ($HPInstalledModule -ne $null) {
-        $HPGetLatestModule = Find-Module -Name "HPCMSL" -ErrorAction Stop -Verbose:$false
+        $HPGetLatestModule = Find-Module -Name "HPCMSL" -Repository $PSRepository -ErrorAction Stop -Verbose:$false
         if ($HPInstalledModule.Version -lt $HPGetLatestModule.Version) {
             Write-Output "Newer HPCMSL version detected, updating from repository"
             $scriptBlock = {
@@ -128,7 +132,7 @@ if ($PackageProvider.Version -ge "2.8.5"){
             try {
                 # Install HP Client Management Script Library
                 Write-Output -Value "Attempting to install HPCMSL module from repository" 
-                Install-Module -Name "HPCMSL" -AcceptLicense -Force -ErrorAction Stop -Verbose:$false
+                Install-Module -Name "HPCMSL" -Repository $PSRepository -AcceptLicense -Force -ErrorAction Stop -Verbose:$false
             } 
             catch [System.Exception] {
                 Write-OutPut -Value "Unable to install HPCMSL module from repository. Error message: $($_.Exception.Message)"; exit 1


### PR DESCRIPTION
This is a fix for a scenario when a devices has multiple PS repositories configured.
And one of them has a manual authentication then the script will hang on trying to authenticate.

Now it will just only try the PS Gallery.